### PR TITLE
Escape more latex special chars in text / Updated documentation

### DIFF
--- a/Helper/Parser.php
+++ b/Helper/Parser.php
@@ -45,6 +45,9 @@ class Parser
     // Remove remaining HTML entities
     $text = preg_replace('/&[a-zA-Z]+;/iu', '', $text);
 
+    // Replace those chars first that will later have a different function
+    $text = str_replace("\\", "\textbackslash ", $text);
+
     // Adjust known characters
     $text = str_replace("ä", "\\\"a", $text);
     $text = str_replace("á", "\\'a", $text);
@@ -111,9 +114,8 @@ class Parser
     $text = str_replace("^", "\\^{}", $text);
     $text = str_replace("{", "\\{", $text);
     $text = str_replace("}", "\\}", $text);
-    $text = str_replace(">", "\langle", $text);
-    $text = str_replace("<", "\rangle", $text);
-    $text = str_replace("\\", "\textbackslash", $text);
+//    $text = str_replace(">", "\\textlangle{}", $text);
+//    $text = str_replace("<", "\\textrangle{}", $text);
 
     // Check for & characters. Inside a tabular(x) env they should not be replaced
     $offset = 0;

--- a/Helper/Parser.php
+++ b/Helper/Parser.php
@@ -104,6 +104,16 @@ class Parser
 
     $text = str_replace("#", "\\#", $text);
     $text = str_replace("_", "\\_", $text);
+    $text = str_replace("$", "\\$", $text);
+    $text = str_replace("%", "\\%", $text);
+    $text = str_replace("&", "\\&", $text);
+    $text = str_replace("~", "\\~{}", $text);
+    $text = str_replace("^", "\\^{}", $text);
+    $text = str_replace("{", "\\{", $text);
+    $text = str_replace("}", "\\}", $text);
+    $text = str_replace(">", "\langle", $text);
+    $text = str_replace("<", "\rangle", $text);
+    $text = str_replace("\\", "\textbackslash", $text);
 
     // Check for & characters. Inside a tabular(x) env they should not be replaced
     $offset = 0;

--- a/Resources/doc/documentation.md
+++ b/Resources/doc/documentation.md
@@ -216,7 +216,7 @@ If you have any character that generates an error, feel create an issue or creat
 
 This bundle also includes a HTML to LaTeX parser, which will parse basic HTML structures and convert it to basic LaTeX syntax. At the moment the following tags are supported: 
 
-`b, strong, em, u, sup, sub (requires fixltx2e package), ol, ul, li, a and p`
+`b, strong, em, u, sup, sub (requires fixltx2e package), ol, ul, li, a, p and br`
 
 NOTE: The parser assumes that the HTML input is generated using a CK-editor instance. When this is not the case, the behaviour might be unexpected!
 


### PR DESCRIPTION
Hey, 

I added your now supported `<br>`-tag to the docs, plus allowed some latex special chars to get escaped. Did not test all of them though...

Thanks&Regards!