### PR TITLE
LatexGenerator.php: Dump latex output to debug toolbar

### DIFF
--- a/Generator/LatexGenerator.php
+++ b/Generator/LatexGenerator.php
@@ -328,7 +328,9 @@ class LatexGenerator
 
       // Check if the pdflatex command completed successfully
       if (!$process->isSuccessful()) {
-        throw new LatexParseException(
+        dump($process->getErrorOutput());
+        dump($process->getOutput());
+        throw new LatexParseException(        
             $texLocation,
             $process->getExitCode(),
             $output,


### PR DESCRIPTION
Dump the output to the debug toolbar so there's no need to look for the log file. If we would dump outside of  `if (!$process->isSuccessful())`, the dump would be mixed into the pdf output on success. We could go further by dumping the log file output as well, but we'd need to check if that exists first, and it's pretty much identical to stdout in nonstopmode.