### PR TITLE
Fix documentation error in Latex/LatexInterface.php

### DIFF
--- a/Latex/LatexInterface.php
+++ b/Latex/LatexInterface.php
@@ -29,7 +29,7 @@ interface LatexInterface
    * Set a specific param in the context for Twig
    *
    * @param string $param
-   * @param string $value
+   * @param mixed $value
    *
    * @return LatexInterface
    */

--- a/Latex/LatexParams.php
+++ b/Latex/LatexParams.php
@@ -26,7 +26,7 @@ class LatexParams {
    * Set a specific parameter for the class
    *
    * @param string $param
-   * @param string $value
+   * @param mixed $value
    *
    * @return LatexInterface $this
    * @throws \BobV\LatexBundle\Exception\LatexException


### PR DESCRIPTION
On line 32, it was specified that the value should be a string, however, a value can be any type, so it should be `@param mixed $value`