### PR TITLE
Fix bug in LockedLatexGenerator

### DIFF
--- a/Generator/LockedLatexGenerator.php
+++ b/Generator/LockedLatexGenerator.php
@@ -80,7 +80,7 @@ class LockedLatexGenerator implements LatexGeneratorInterface, LockedLatexGenera
   public function createTexResponse(LatexBaseInterface $latex, bool $download = true) {
     $this->ensureLock();
 
-    return $this->createTexResponse($latex, $download);
+    return $this->generator->createTexResponse($latex, $download);
   }
 
   /**


### PR DESCRIPTION
Currently, calling `LockedLatexGenerator->createTexResponse` will result in an endless loop. This PR fixes that.