### PR TITLE
Remove spaces after escaped curly brackets

### DIFF
--- a/Helper/Parser.php
+++ b/Helper/Parser.php
@@ -94,8 +94,8 @@ class Parser
     // LaTeX command characters if required
     if ($removeLatex) {
       $text = str_replace("\\", "\\textbackslash ", $text);
-      $text = str_replace("{", "\\{ ", $text);
-      $text = str_replace("}", "\\} ", $text);
+      $text = str_replace("{", "\\{", $text);
+      $text = str_replace("}", "\\}", $text);
       $text = str_replace("[", "\\[ ", $text);
       $text = str_replace("]", "\\] ", $text);
     }


### PR DESCRIPTION
Prevents extra spaces from being placed in the text when using curly brackets, and the spaces are not needed for proper escaping.